### PR TITLE
Fix arrow image height on FF

### DIFF
--- a/components/QuoteScroller.vue
+++ b/components/QuoteScroller.vue
@@ -45,10 +45,10 @@
         padding: 0;
         transition: opacity .4s ease-in .2s;
         position: absolute;
-        top: 0;
+        top: 50%;
         bottom: 0;
+        margin-top: -1.25rem; // Half the height
         display: flex;
-        height: 100%;
 
         &:hover {
           cursor: pointer;


### PR DESCRIPTION
Fixes this bug:
<img width="808" alt="screen shot 2018-11-26 at 10 16 18 am" src="https://user-images.githubusercontent.com/171493/49023107-6ba81000-f164-11e8-8e25-970d1165e1a2.png">
